### PR TITLE
added logout link in profile.handlebars and blocked going to the prof…

### DIFF
--- a/Unsolved/controllers/authcontroller.js
+++ b/Unsolved/controllers/authcontroller.js
@@ -10,9 +10,9 @@ exports.signin = function(req, res) {
     res.render('signin');
  
 }
-exports.dashboard = function(req, res) {
+exports.profile = function(req, res) {
  
-    res.render('dashboard');
+    res.render('profile');
  
 }
 exports.logout = function(req, res) {

--- a/Unsolved/routes/auth.js
+++ b/Unsolved/routes/auth.js
@@ -13,7 +13,7 @@ module.exports = function(app,passport) {
         }
     )); 
 
-    app.get('/dashboard',isLoggedIn, authController.dashboard);
+    app.get('/profile',isLoggedIn, authController.profile);
 
     app.get('/logout',authController.logout);
 

--- a/Unsolved/server.js
+++ b/Unsolved/server.js
@@ -25,10 +25,10 @@ app.engine(
       msg: "Welcome!",
   });
   });
-  app.get("/profile", function(req, res) {
-    res.render("profile", {
-  });
-  });
+  // app.get("/profile", function(req, res) {
+  //   res.render("profile", {
+  // });
+  // });
 
 //bodyParser setup 
 app.use(bodyParser.urlencoded({ extended:true}));

--- a/Unsolved/views/profile.handlebars
+++ b/Unsolved/views/profile.handlebars
@@ -16,6 +16,7 @@
 			<a class="nav-item nav-link" href="#">News</a>
 			<a class="nav-item nav-link" href="#">FTT Member Information</a>
 			<a class="nav-item nav-link" href="#">Member Login</a>
+			<a class="nav-item nav-link" href="/logout" name="logout" method="get" action="/logout" >Logout</a>
 		</span>
 	</nav>
     <link href="css/bootstrap.min.css" rel="stylesheet">


### PR DESCRIPTION
Added logout link in profile.handlebars and blocked going to the profile page without signin or signup. Because that is an expected behavior. So, if you are not signin typing URL localhost:3000/profile will take you to the signin page. If you want to skip signin step,  and go to the profile page for testing purpose you can just uncomment below lines in server.js. but please comment them out again before you push your changes to the remote repo. 

// app.get("/profile", function(req, res) {
  //   res.render("profile", {
  // });
  // });